### PR TITLE
Adds support for negating rewrite conditions

### DIFF
--- a/src/MustardBlack.Build.Assets/MustardBlack.Build.Assets.csproj
+++ b/src/MustardBlack.Build.Assets/MustardBlack.Build.Assets.csproj
@@ -48,7 +48,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="paket.references" />
     <None Include="paket.template" />
   </ItemGroup>
   <ItemGroup>

--- a/src/MustardBlack.Tests/ModRewrite/RewriteCondAndRule/Fail/NegatedCondition.cs
+++ b/src/MustardBlack.Tests/ModRewrite/RewriteCondAndRule/Fail/NegatedCondition.cs
@@ -1,0 +1,11 @@
+namespace MustardBlack.Tests.ModRewrite.RewriteCondAndRule.Fail
+{
+	sealed class NegatedCondition : FailureModRewriteSpecification
+	{
+		protected override string Rules => @"
+RewriteCond %{REQUEST_URI} !foo-bar
+RewriteRule .* /baz";
+
+		protected override string RequestUrl => "https://www.unidays.test/foo-bar";
+	}
+}

--- a/src/MustardBlack.Tests/ModRewrite/RewriteCondAndRule/Success/NegatedCondition.cs
+++ b/src/MustardBlack.Tests/ModRewrite/RewriteCondAndRule/Success/NegatedCondition.cs
@@ -1,0 +1,16 @@
+using System.Net;
+
+namespace MustardBlack.Tests.ModRewrite.RewriteCondAndRule.Success
+{
+	sealed class NegatedCondition : SuccessfulRedirectModRewriteSpecification
+	{
+		protected override string Rules => @"
+RewriteCond %{REQUEST_URI} !quux
+RewriteRule .* /baz";
+
+		protected override string RequestUrl => "https://www.unidays.test/foo-bar";
+
+		protected override string ExpectedRedirectUrl => "https://www.unidays.test/baz";
+		protected override HttpStatusCode ExpectedStatusCode => HttpStatusCode.Redirect;
+	}
+}

--- a/src/MustardBlack.Tests/MustardBlack.Tests.csproj
+++ b/src/MustardBlack.Tests/MustardBlack.Tests.csproj
@@ -104,10 +104,12 @@
     <Compile Include="ModRewrite\Options\DefaultRedirect.cs" />
     <Compile Include="ModRewrite\Options\GlobalCaseInsensitivity.cs" />
     <Compile Include="ModRewrite\RewriteCondAndRule\Fail\HostConditionAndSimplePath.cs" />
+    <Compile Include="ModRewrite\RewriteCondAndRule\Fail\NegatedCondition.cs" />
     <Compile Include="ModRewrite\RewriteCondAndRule\Fail\QueryStringAndSimplePath.cs" />
     <Compile Include="ModRewrite\RewriteCondAndRule\Fail\RequestUriAndSimplePath.cs" />
     <Compile Include="ModRewrite\RewriteCondAndRule\Success\HostConditionAndSimplePath.cs" />
     <Compile Include="ModRewrite\RewriteCondAndRule\Success\HostConditionCaptureGroupAndSimplePath.cs" />
+    <Compile Include="ModRewrite\RewriteCondAndRule\Success\NegatedCondition.cs" />
     <Compile Include="ModRewrite\RewriteCondAndRule\Success\QueryStringAndSimplePath.cs" />
     <Compile Include="ModRewrite\RewriteCondAndRule\Success\RequestUriAndSimplePath.cs" />
     <Compile Include="ModRewrite\RewriteRuleOnly\Success\LeadingSlash.cs" />

--- a/src/MustardBlack/ModRewrite/Engine.cs
+++ b/src/MustardBlack/ModRewrite/Engine.cs
@@ -27,12 +27,18 @@ namespace MustardBlack.ModRewrite
 					var condition = ruleset.Conditions[conditionIndex];
 					
 					var match = condition.Matches(request);
-					if (match.Success)
+					if (match.Success && !condition.Negate)
 					{
 						log.Debug("ModRewrite: Rulset {index}, Condition {conditionIndex}: {condition}: Matched, proceeding", ruleIndex, conditionIndex, condition.ToString());
 
 						for (var i = 1; i < match.Groups.Count; i++)
 							conditionArgs.Add(match.Groups[i].Value);
+						continue;
+					}
+
+					if (!match.Success && condition.Negate)
+					{
+						log.Debug("ModRewrite: Rulset {index}, Condition {conditionIndex}: {condition}: Negated Match, proceeding", ruleIndex, conditionIndex, condition.ToString());
 						continue;
 					}
 

--- a/src/MustardBlack/ModRewrite/RewriteCond.cs
+++ b/src/MustardBlack/ModRewrite/RewriteCond.cs
@@ -12,7 +12,8 @@ namespace MustardBlack.ModRewrite
 		public RewriteCondFlags Flags { get; set; }
 		public string TestString { get; set; }
 		public Regex Condition { get; set; }
-		string source;
+        public bool Negate { get; set; }
+        string source;
 
 		[Flags]
 		public enum RewriteCondFlags
@@ -25,18 +26,21 @@ namespace MustardBlack.ModRewrite
 			var flags = ParseFlags(lineTokens);
 
 			var regexOptions = flags.HasFlag(RewriteCondFlags.CaseInsensitive) || options.GlobalCaseInsensitivity ? RegexOptions.IgnoreCase : RegexOptions.None;
-			var condition = new Regex(lineTokens[2], regexOptions, TimeSpan.FromMilliseconds(500));
+			var pattern = lineTokens[2];
+			var negate = pattern.StartsWith("!");
+			var condition = new Regex(negate ? pattern.Substring(1) : pattern, regexOptions, TimeSpan.FromMilliseconds(500));
 
 			return new RewriteCond
 			{
 				TestString = lineTokens[1],
 				Flags = flags,
 				Condition = condition,
+				Negate = negate,
 				source = line
 			};
 		}
 
-		static RewriteCondFlags ParseFlags(IReadOnlyList<string> lineTokens)
+        static RewriteCondFlags ParseFlags(IReadOnlyList<string> lineTokens)
 		{
 			var flags = (RewriteCondFlags) 0;
 			if (lineTokens.Count == 4)


### PR DESCRIPTION
The mod_rewrite [docs](https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewritecond) state

> You can prefix the pattern string with a '!' character (exclamation mark) to negate the result of the condition, no matter what kind of CondPattern is used.

This adds support for doing just that.