### PR TITLE
Changed AreaJavascriptHandler MIME return type to application/javascript

### DIFF
--- a/src/MustardBlack/Assets/Javascript/AreaJavascriptHandler.cs
+++ b/src/MustardBlack/Assets/Javascript/AreaJavascriptHandler.cs
@@ -24,7 +24,7 @@ namespace MustardBlack.Assets.Javascript
 
 			var asset = this.assetLoader.GetAsset(path, AssetFormat.Js);
 			
-			return new FileContentResult("text/js", Encoding.UTF8.GetBytes(asset));
+			return new FileContentResult("application/javascript", Encoding.UTF8.GetBytes(asset));
 		}
 	}
 }


### PR DESCRIPTION
Previous version of AreaJavascriptHandler returned a MIME type of test/js. This created a problem with the Chrome returning the following error

`Refused to execute script from 'https://xx.com/main.js' because its MIME type ('text/js') is not executable, and strict MIME type checking is enabled.`

`text/js` is invalid as a MIME type so this has been updated to `application/javascript`