### PR TITLE
Remove warning log from CookieTempDataMechanism

### DIFF
--- a/src/MustardBlack/TempData/CookieTempDataMechanism.cs
+++ b/src/MustardBlack/TempData/CookieTempDataMechanism.cs
@@ -1,17 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reflection;
 using MustardBlack.Hosting;
 using MustardBlack.Pipeline;
 using Newtonsoft.Json;
-using Serilog;
 
 namespace MustardBlack.TempData
 {
 	public sealed class CookieTempDataMechanism : ITempDataMechanism
 	{
-		static readonly ILogger log = Log.ForContext(MethodBase.GetCurrentMethod().DeclaringType);
-
 		public static Func<IRequest, string> GetCookieDomain = request => request.Url.Domain();
 
 		public void SetTempData(PipelineContext context, IDictionary<string, object> tempData)
@@ -20,10 +16,6 @@ namespace MustardBlack.TempData
 				return;
 
 			var serializeObject = JsonConvert.SerializeObject(tempData);
-
-			// Temporary logging to see if we're outputting commas in cookies, we shouldnt be as it can b0rk things.
-			if (serializeObject != null && serializeObject.Contains(","))
-				log.Warning("Temp data contains a comma `{0}`", serializeObject);
 
 			var cookie = new ResponseCookie(
 				"temp",


### PR DESCRIPTION
We are The Monitoring Guild.
![](https://media.tenor.com/images/7e5c0701fba480e5c59ccf400ea18e55/tenor.gif)

The warning log removed here has been deemed no longer fit for purpose and is a prime culprit in current unhelpful noise in Seq.

Please consider this removal for approval. Repproval?

Expect us.