### PR TITLE
Improving the error detail on the rethrown error when compiling views

### DIFF
--- a/src/MustardBlack.Assets.YuiCompressor/YuiJavascriptPreprocessor.cs
+++ b/src/MustardBlack.Assets.YuiCompressor/YuiJavascriptPreprocessor.cs
@@ -32,12 +32,12 @@ namespace MustardBlack.Assets.YuiCompressor
             catch (EcmaScript.NET.EcmaScriptRuntimeException e)
             {
                 Console.WriteLine($"YUI Compression Error: '{e.Message}'\nJavascript Syntax Error: '{e.LineSource}'\nLine {e.LineNumber}\nFile: {assetPath}");
-                throw;
+                throw new Exception($"YUI Compression Error: '{e.Message}'\nJavascript Syntax Error: '{e.LineSource}'\nLine {e.LineNumber}\nFile: {assetPath}");
             }
             catch (Exception e)
             {
                 Console.WriteLine($"YUI Compression Error: {e.Message}: File: {assetPath}");
-                throw;
+                throw new Exception($"YUI Compression Error: {e.Message}: File: {assetPath}");
             }
         }
     }


### PR DESCRIPTION
Node's `shell.exec` doesn't seem to capture the stdout properly so we can't see things that we `Console.WriteLine` while compiling views. This means the detail around errors in co-located JavaScript are swallowed. I've added more detail to the re-thrown error (which is shown in the logs) so we can see what's actually gone wrong.